### PR TITLE
feat: update GitHub Actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,13 +11,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # 1.11.6
+      - uses: actions/create-github-app-token@v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # 4.2.0
+      - uses: actions/checkout@v4.2.2
+      - uses: googleapis/release-please-action@v4.2.0
         with:
           release-type: go
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,23 +8,23 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # 3.0.1
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.6.0
+      - uses: pre-commit/action@v3.0.1
   code-qa:
     runs-on: ubuntu-latest
     needs: pre-commit
     permissions:
       pull-requests: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # 3.0.2
+      - uses: actions/checkout@v4.2.2
+      - uses: dorny/paths-filter@v3.0.2
         id: changes
         with:
           filters: |-
             go:
               - '**/*.go'
       - if: steps.changes.outputs.go == 'true'
-        uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e # 8.0.0
+        uses: dagger/dagger-for-github@8.0.0
         with:
           call: pull-request

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,14 +9,14 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # 1.11.6
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/create-github-app-token@v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: dagger/dagger-for-github@e47aba410ef9bb9ed81a4d2a97df31061e5e842e # 8.0.0
+      - uses: dagger/dagger-for-github@8.0.0
         with:
           verb: call
           args: "release-cli --tag=$TAG --token=env://TOKEN"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
-        uses: "actions/create-github-app-token@v1.11.0"
+        uses: "actions/create-github-app-token@v2.0.6"
         id: app-token
         with:
           app-id: "${{ vars.APP_ID }}"
@@ -28,7 +28,7 @@ jobs:
         with:
           token: "${{ steps.app-token.outputs.token }}"
       - name: Renovate
-        uses: "renovatebot/github-action@v41.0.2"
+        uses: "renovatebot/github-action@v43.0.5"
         with:
           configurationFile: ".github/renovate.json"
           token: "${{ steps.app-token.outputs.token }}"


### PR DESCRIPTION
This does unpin everything, but if Renovate starts working we will pin all the actions shortly.